### PR TITLE
Add UUID utility for LoadMasterData

### DIFF
--- a/project 3/package.json
+++ b/project 3/package.json
@@ -15,7 +15,8 @@
     "lucide-react": "^0.344.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.22.3"
+    "react-router-dom": "^6.22.3",
+    "uuid": "^9.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",

--- a/project 3/src/components/LoadManagement/LoadMasterData.tsx
+++ b/project 3/src/components/LoadManagement/LoadMasterData.tsx
@@ -4,6 +4,7 @@ import LoadingSpinner from '../common/LoadingSpinner';
 import ErrorMessage from '../../components/common/ErrorMessage';
 import { Pencil, Save, Trash2 } from 'lucide-react';
 import { fetchPlanningSteps, savePlanningStep, updatePlanningStep, deletePlanningStep } from '../../lib/supabase';
+import { generateUUID } from '../../utils/uuid';
 import type { PlanningStep } from '../../types';
 
 const TABS = [
@@ -48,7 +49,7 @@ export default function LoadMasterData() {
     setPlanningSteps(prev => [
       ...prev,
       {
-        id: crypto.randomUUID(), // Temporary ID
+        id: generateUUID(),
         name: '',
         role_in_charge: '',
         starting_step: 'BLU',

--- a/project 3/src/utils/uuid.ts
+++ b/project 3/src/utils/uuid.ts
@@ -1,0 +1,9 @@
+import { v4 as uuidv4 } from 'uuid';
+
+export const generateUUID = () => {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return uuidv4();
+};
+


### PR DESCRIPTION
## Summary
- implement `generateUUID` utility fallback to `uuid`'s `v4`
- replace direct `crypto.randomUUID` call in `LoadMasterData`
- declare `uuid` dependency in package.json

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684add16616883248b13314e38fb3910