### PR TITLE
Add env example and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # AUTOBEL
+
+Before running the project located in `project 3`, copy the example environment file:
+
+```bash
+cp "project 3/.env.example" "project 3/.env"
+```
+
+This will create a `.env` file containing `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` that you can adapt to your real credentials.

--- a/project 3/.env.example
+++ b/project 3/.env.example
@@ -1,0 +1,2 @@
+VITE_SUPABASE_URL=https://example.supabase.co
+VITE_SUPABASE_ANON_KEY=exampleanonkey


### PR DESCRIPTION
## Summary
- add `.env.example` with placeholder Supabase settings
- document copying the env example before running the project

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684add16a6f0832485f8b88ce4133782