### PR TITLE
Add tests for QuotationPage and MasterDataPage

### DIFF
--- a/project 3/src/pages/__tests__/MasterDataPage.test.tsx
+++ b/project 3/src/pages/__tests__/MasterDataPage.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import MasterDataPage from '../MasterDataPage';
+
+const fromMock = vi.fn();
+
+vi.mock('../../lib/supabase', () => ({
+  supabase: {
+    from: fromMock,
+    auth: { getUser: vi.fn() }
+  }
+}));
+
+const oemData = [{ id: '1', name: 'OEM1', abbreviation: 'O1', country: 'US' }];
+
+beforeEach(() => {
+  fromMock.mockImplementation(() => ({
+    select: vi.fn(() => Promise.resolve({ data: oemData, error: null })),
+    insert: vi.fn(() => Promise.resolve({ error: null })),
+    update: vi.fn(() => ({ eq: vi.fn(() => Promise.resolve({ error: null })) })),
+    delete: vi.fn(() => ({ eq: vi.fn(() => Promise.resolve({ error: null })) }))
+  }));
+});
+
+describe('MasterDataPage', () => {
+  it('displays table after selecting a category', async () => {
+    render(<MasterDataPage />);
+
+    await userEvent.click(screen.getByText('OEM'));
+
+    expect(await screen.findByRole('button', { name: /Add New/i })).toBeInTheDocument();
+    expect(screen.getByText('OEM1')).toBeInTheDocument();
+  });
+
+  it('opens form modal when adding new item', async () => {
+    render(<MasterDataPage />);
+    await userEvent.click(screen.getByText('OEM'));
+
+    const addBtn = await screen.findByRole('button', { name: /Add New/i });
+    await userEvent.click(addBtn);
+    expect(screen.getByText('Add New OEM')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: /Cancel/i }));
+    expect(screen.queryByText('Add New OEM')).not.toBeInTheDocument();
+  });
+
+  it('opens delete confirmation modal', async () => {
+    render(<MasterDataPage />);
+    await userEvent.click(screen.getByText('OEM'));
+    const row = await screen.findByText('OEM1');
+    const buttons = within(row.closest('tr') as HTMLElement).getAllByRole('button');
+    await userEvent.click(buttons[1]);
+    expect(screen.getByText(/Confirm Delete/i)).toBeInTheDocument();
+  });
+});

--- a/project 3/src/pages/__tests__/QuotationPage.test.tsx
+++ b/project 3/src/pages/__tests__/QuotationPage.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import QuotationPage from '../QuotationPage';
+
+const mockFetchRFQs = vi.fn();
+const mockFetchRFQComments = vi.fn();
+const mockDeleteRFQ = vi.fn();
+
+vi.mock('../../lib/supabase', () => ({
+  fetchRFQs: mockFetchRFQs,
+  fetchRFQComments: mockFetchRFQComments,
+  deleteRFQ: mockDeleteRFQ,
+  fetchRFQ: vi.fn(),
+  updateRFQ: vi.fn(),
+  addRFQComment: vi.fn(),
+  supabase: { auth: { getUser: vi.fn() }, from: vi.fn() }
+}));
+
+const rfqs = [
+  {
+    id: '1',
+    reference: 'REF1',
+    opportunity: 'Opp1',
+    customer: 'Cust1',
+    program: 'Prog1',
+    phase_status: 'OPEN',
+    due_date: '2024-01-01',
+    created_at: '2024-01-01',
+    rfq_planning: [],
+    rfq_worksharing: []
+  },
+  {
+    id: '2',
+    reference: 'REF2',
+    opportunity: 'Opp2',
+    customer: 'Cust2',
+    program: 'Prog2',
+    phase_status: 'OPEN',
+    due_date: '2024-01-02',
+    created_at: '2024-01-02',
+    rfq_planning: [],
+    rfq_worksharing: []
+  }
+];
+
+const comment = {
+  id: 'c1',
+  rfq_id: '1',
+  comment: 'latest',
+  created_at: '2024-01-03',
+  created_by: '1'
+};
+
+describe('QuotationPage', () => {
+  beforeEach(() => {
+    mockFetchRFQs.mockReset();
+    mockFetchRFQComments.mockReset();
+    mockDeleteRFQ.mockReset();
+  });
+
+  it('renders RFQ rows after loading', async () => {
+    mockFetchRFQs.mockResolvedValue(rfqs);
+    mockFetchRFQComments.mockImplementation(async (id: string) => id === '1' ? [comment] : []);
+
+    render(<QuotationPage />);
+
+    expect(await screen.findByText('REF1')).toBeInTheDocument();
+    expect(screen.getByText('REF2')).toBeInTheDocument();
+    expect(screen.getByText('latest')).toBeInTheDocument();
+    expect(mockFetchRFQs).toHaveBeenCalled();
+  });
+
+  it('allows deleting an RFQ', async () => {
+    mockFetchRFQs.mockResolvedValue(rfqs);
+    mockFetchRFQComments.mockResolvedValue([]);
+    mockDeleteRFQ.mockResolvedValue(undefined);
+
+    render(<QuotationPage />);
+
+    await screen.findByText('REF1');
+
+    const deleteBtn = screen.getAllByTitle('Delete')[0];
+    await userEvent.click(deleteBtn);
+    expect(screen.getByText(/Confirmer la suppression/i)).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: /Supprimer/i }));
+    expect(mockDeleteRFQ).toHaveBeenCalledWith('1');
+  });
+});


### PR DESCRIPTION
## Summary
- create `QuotationPage` tests for rendering and deletion flow
- add tests for `MasterDataPage` modal and delete modal

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684add1787648324bbb19f0f79f394d1