### PR TITLE
Add CI, license and env example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: 'project 3'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm test --if-present

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 marcmx1973
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ npm install
 
 ## Configuration des variables d'environnement Supabase
 
-Créez un fichier `.env` (ou `.env.local`) à la racine de `project 3` contenant :
+Un fichier `.env.example` est fourni dans `project 3`. Copiez-le en `.env` (ou `.env.local`) et renseignez les valeurs appropriées :
 
 ```
 VITE_SUPABASE_URL=<url fournie par Supabase>
@@ -56,3 +56,7 @@ supabase db reset
 ```
 
 Cette commande applique toutes les migrations et prépare la base pour l'application.
+
+## Licence
+
+Ce projet est distribué sous licence [MIT](LICENSE).

--- a/project 3/.env.example
+++ b/project 3/.env.example
@@ -1,0 +1,3 @@
+# Example environment configuration for Autobel
+VITE_SUPABASE_URL=https://your-project.supabase.co
+VITE_SUPABASE_ANON_KEY=your-anon-key


### PR DESCRIPTION
## Summary
- add CI workflow for Node and Vitest
- provide MIT license file
- add example environment file
- document `.env.example` and license in README

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ae2deaf048324b6733b591b624356