### PR TITLE
Add Node.js CI workflow

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -1,0 +1,37 @@
+name: Node.js CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: "project 3"
+
+      - name: Lint
+        run: npm run lint
+        working-directory: "project 3"
+
+      - name: Test
+        run: npm test
+        working-directory: "project 3"
+
+      - name: Build
+        run: npm run build
+        working-directory: "project 3"


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for Node.js

## Testing
- `npm ci` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: package '@eslint/js' not found)*
- `npm test` *(fails: vitest not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ae4b21b6883248b65b305c5d843c1