### PR TITLE
Update README with npm install note

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,15 @@ cd "project 3"
 npm install
 ```
 
+## Avant les tests et le développement
+
+Assurez-vous d'installer les dépendances dans `project 3/` avant d'exécuter `npm run dev` ou `npm test`.
+
+```bash
+cd "project 3"
+npm install   # ou npm ci
+```
+
 ## Configuration des variables d'environnement Supabase
 
 Créez un fichier `.env` (ou `.env.local`) à la racine de `project 3` contenant :


### PR DESCRIPTION
## Summary
- clarify that developers must run `npm install` (or `npm ci`) in `project 3/` before using test or development commands

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684ae4b56aac8324b03d7b0f1372cb74