### PR TITLE
Add Node engine requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ AUTOBEL/
 
 ## Installation des dépendances
 
+Ce projet nécessite Node.js >= 20.
+
 ```bash
 cd "project 3"
 npm install

--- a/project 3/package.json
+++ b/project 3/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
   "scripts": {
     "dev": "vite",
     "build": "vite build",


### PR DESCRIPTION
## Summary
- specify Node >=20 in project 3's package.json
- document required Node version in README

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ae66f3f888324a917156e104dfa8f