### PR TITLE
Add LoadManagement component tests

### DIFF
--- a/project 3/src/components/LoadManagement/__tests__/CapacityLoadAnalysis.test.tsx
+++ b/project 3/src/components/LoadManagement/__tests__/CapacityLoadAnalysis.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CapacityLoadAnalysis from '../CapacityLoadAnalysis';
+import type { MasterDataType } from '../../../types';
+
+const fetchRFQs = vi.fn();
+const fetchNominalCapacities = vi.fn();
+const fetchLoadPerUnit = vi.fn();
+
+vi.mock('../../../lib/supabase', () => ({
+  fetchRFQs
+}));
+
+vi.mock('../../../lib/capacity', () => ({
+  fetchNominalCapacities,
+  fetchLoadPerUnit
+}));
+
+const masterData: MasterDataType = {
+  OEM: [],
+  PROGRAM: [],
+  CUSTOMER: [],
+  PROCESS: [{ id: 'proc1', STANDARD_PROCESS: 'Proc1', PROCESS_DESCRIPTION: '' }],
+  'GROUP DIVISION': [{ id: 'div1', DIVISION_NAME: 'DIV1', DIVISION_ABB: '' }],
+  SITE: [{ id: 'site1', SITE_NAME: 'Site1', DIVISION_NAME: 'DIV1' }],
+  PLANT: [{ id: 'plant1', PLANT_NAME: 'Plant1', SITE_NAME: 'Site1' }],
+  'EXISTING PROCESS': [
+    { id: 'ep1', STANDARD_PROCESS: 'Proc1', PLANT_NAME: 'Plant1' }
+  ],
+  DEPARTMENT: [],
+  ROLE: [],
+  STAKEHOLDER: []
+};
+
+vi.mock('../../../hooks/useMasterData', () => ({
+  useMasterData: () => ({ masterData, loading: false })
+}));
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2024-01-01T00:00:00Z'));
+  fetchRFQs.mockReset();
+  fetchNominalCapacities.mockReset();
+  fetchLoadPerUnit.mockReset();
+
+  fetchRFQs.mockResolvedValue([
+    {
+      reference: 'RFQ1',
+      rfq_planning: [
+        { team: 'PIN', planned_date: '2024-01-02' },
+        { team: 'EOQ', planned_date: '2024-01-08' }
+      ],
+      rfq_worksharing: [
+        { plant: 'Plant1', process: 'Proc1', qty_to_quote: 10 }
+      ]
+    }
+  ]);
+  fetchNominalCapacities.mockResolvedValue([
+    { process_id: 'proc1', plant_id: 'plant1', weekly_hours: 40 }
+  ]);
+  fetchLoadPerUnit.mockResolvedValue([
+    { process_id: 'proc1', plant_id: 'plant1', hours_per_unit: 1 }
+  ]);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('CapacityLoadAnalysis', () => {
+  it('displays load chart after selecting division', async () => {
+    render(<CapacityLoadAnalysis />);
+
+    await userEvent.click(screen.getByLabelText('DIV1'));
+
+    expect(await screen.findByText('Plant1')).toBeInTheDocument();
+    expect(screen.getByText('10.0h')).toBeInTheDocument();
+    expect(fetchRFQs).toHaveBeenCalled();
+  });
+
+  it('opens week details popup on cell click', async () => {
+    render(<CapacityLoadAnalysis />);
+    await userEvent.click(screen.getByLabelText('DIV1'));
+
+    const row = await screen.findByText('Plant1');
+    const cell = within(row.closest('tr') as HTMLElement).getByText('10.0h');
+    await userEvent.click(cell);
+
+    expect(
+      await screen.findByText('Week 1 (2024) Load Details')
+    ).toBeInTheDocument();
+  });
+});

--- a/project 3/src/components/LoadManagement/__tests__/LoadPerUnit.test.tsx
+++ b/project 3/src/components/LoadManagement/__tests__/LoadPerUnit.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import LoadPerUnit from '../LoadPerUnit';
+import type { MasterDataType } from '../../../types';
+
+const fetchLoadPerUnit = vi.fn();
+const saveLoadPerUnit = vi.fn();
+
+vi.mock('../../../lib/capacity', () => ({
+  fetchLoadPerUnit,
+  saveLoadPerUnit
+}));
+
+const masterData: MasterDataType = {
+  OEM: [],
+  PROGRAM: [],
+  CUSTOMER: [],
+  PROCESS: [{ id: 'proc1', STANDARD_PROCESS: 'Proc1', PROCESS_DESCRIPTION: '' }],
+  'GROUP DIVISION': [{ id: 'div1', DIVISION_NAME: 'DIV1', DIVISION_ABB: '' }],
+  SITE: [{ id: 'site1', SITE_NAME: 'Site1', DIVISION_NAME: 'DIV1' }],
+  PLANT: [{ id: 'plant1', PLANT_NAME: 'Plant1', SITE_NAME: 'Site1' }],
+  'EXISTING PROCESS': [
+    { id: 'ep1', STANDARD_PROCESS: 'Proc1', PLANT_NAME: 'Plant1' }
+  ],
+  DEPARTMENT: [],
+  ROLE: [],
+  STAKEHOLDER: []
+};
+
+vi.mock('../../../hooks/useMasterData', () => ({
+  useMasterData: () => ({ masterData, loading: false })
+}));
+
+beforeEach(() => {
+  fetchLoadPerUnit.mockReset();
+  saveLoadPerUnit.mockReset();
+  fetchLoadPerUnit.mockResolvedValue([
+    { process_id: 'proc1', plant_id: 'plant1', hours_per_unit: 2 }
+  ]);
+  saveLoadPerUnit.mockResolvedValue({});
+});
+
+describe('LoadPerUnit', () => {
+  it('renders load rows after selecting division and site', async () => {
+    render(<LoadPerUnit />);
+
+    await userEvent.click(screen.getByLabelText('DIV1'));
+    await userEvent.click(screen.getByLabelText('Site1'));
+
+    expect(await screen.findByText('Plant1')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('2')).toBeInTheDocument();
+    expect(fetchLoadPerUnit).toHaveBeenCalled();
+  });
+
+  it('saves updated load value', async () => {
+    render(<LoadPerUnit />);
+
+    await userEvent.click(screen.getByLabelText('DIV1'));
+    await userEvent.click(screen.getByLabelText('Site1'));
+
+    const input = (await screen.findByDisplayValue('2')) as HTMLInputElement;
+    await userEvent.clear(input);
+    await userEvent.type(input, '5');
+
+    const row = input.closest('tr') as HTMLElement;
+    await userEvent.click(within(row).getByRole('button'));
+
+    expect(saveLoadPerUnit).toHaveBeenCalledWith('proc1', 'plant1', 5);
+  });
+});

--- a/project 3/src/components/LoadManagement/__tests__/NominalCapacity.test.tsx
+++ b/project 3/src/components/LoadManagement/__tests__/NominalCapacity.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import NominalCapacity from '../NominalCapacity';
+import type { MasterDataType } from '../../../types';
+
+const fetchNominalCapacities = vi.fn();
+const saveNominalCapacity = vi.fn();
+
+vi.mock('../../../lib/capacity', () => ({
+  fetchNominalCapacities,
+  saveNominalCapacity
+}));
+
+const masterData: MasterDataType = {
+  OEM: [],
+  PROGRAM: [],
+  CUSTOMER: [],
+  PROCESS: [{ id: 'proc1', STANDARD_PROCESS: 'Proc1', PROCESS_DESCRIPTION: '' }],
+  'GROUP DIVISION': [{ id: 'div1', DIVISION_NAME: 'DIV1', DIVISION_ABB: '' }],
+  SITE: [{ id: 'site1', SITE_NAME: 'Site1', DIVISION_NAME: 'DIV1' }],
+  PLANT: [{ id: 'plant1', PLANT_NAME: 'Plant1', SITE_NAME: 'Site1' }],
+  'EXISTING PROCESS': [
+    { id: 'ep1', STANDARD_PROCESS: 'Proc1', PLANT_NAME: 'Plant1' }
+  ],
+  DEPARTMENT: [],
+  ROLE: [],
+  STAKEHOLDER: []
+};
+
+vi.mock('../../../hooks/useMasterData', () => ({
+  useMasterData: () => ({ masterData, loading: false })
+}));
+
+beforeEach(() => {
+  fetchNominalCapacities.mockReset();
+  saveNominalCapacity.mockReset();
+  fetchNominalCapacities.mockResolvedValue([
+    { process_id: 'proc1', plant_id: 'plant1', weekly_hours: 5 }
+  ]);
+  saveNominalCapacity.mockResolvedValue({});
+});
+
+describe('NominalCapacity', () => {
+  it('renders capacity rows after selecting division and site', async () => {
+    render(<NominalCapacity />);
+
+    await userEvent.click(screen.getByLabelText('DIV1'));
+    await userEvent.click(screen.getByLabelText('Site1'));
+
+    expect(await screen.findByText('Plant1')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('5')).toBeInTheDocument();
+    expect(fetchNominalCapacities).toHaveBeenCalled();
+  });
+
+  it('saves updated capacity value', async () => {
+    render(<NominalCapacity />);
+
+    await userEvent.click(screen.getByLabelText('DIV1'));
+    await userEvent.click(screen.getByLabelText('Site1'));
+
+    const input = (await screen.findByDisplayValue('5')) as HTMLInputElement;
+    await userEvent.clear(input);
+    await userEvent.type(input, '20');
+
+    const row = input.closest('tr') as HTMLElement;
+    await userEvent.click(within(row).getByRole('button'));
+
+    expect(saveNominalCapacity).toHaveBeenCalledWith('proc1', 'plant1', 20);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for NominalCapacity with mocked capacity functions
- add tests for LoadPerUnit with mocked capacity functions
- add tests for CapacityLoadAnalysis with mocked Supabase calls

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ae66dcf948324b770bf698da2c6d7