### PR TITLE
Mock supabase for NewQuotePage tests

### DIFF
--- a/project 3/src/pages/__tests__/NewQuotePage.test.tsx
+++ b/project 3/src/pages/__tests__/NewQuotePage.test.tsx
@@ -1,7 +1,15 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import NewQuotePage from '../NewQuotePage';
+
+const mockFetchMasterData = vi.fn();
+const mockSaveRFQ = vi.fn();
+
+vi.mock('../../lib/supabase', () => ({
+  fetchMasterData: mockFetchMasterData,
+  saveRFQ: mockSaveRFQ
+}));
 
 // Helper function to render the component with router context
 const renderNewQuotePage = () => {
@@ -14,6 +22,21 @@ const renderNewQuotePage = () => {
 
 describe('NewQuotePage Layout Tests', () => {
   beforeEach(() => {
+    mockFetchMasterData.mockReset();
+    mockSaveRFQ.mockReset();
+    mockFetchMasterData.mockResolvedValue({
+      OEM: [],
+      PROGRAM: [],
+      CUSTOMER: [],
+      PROCESS: [],
+      'GROUP DIVISION': [],
+      SITE: [],
+      PLANT: [],
+      'EXISTING PROCESS': [],
+      DEPARTMENT: [],
+      ROLE: [],
+      STAKEHOLDER: []
+    });
     renderNewQuotePage();
   });
 


### PR DESCRIPTION
## Summary
- mock Supabase utilities in `NewQuotePage` tests
- ensure master data fetch resolves to dummy data before each test

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aebb3f6ac8324b8ccf65d04734d27